### PR TITLE
Adding remote_src: true

### DIFF
--- a/tasks/userjs.yml
+++ b/tasks/userjs.yml
@@ -30,6 +30,7 @@
         dest: "{{ fxjs_path }}"
         mode: '0644'
         backup: yes
+        remote_src: true
       when: not fxjs.stat.exists
 
     - name: Configure as default pref


### PR DESCRIPTION
This addresses issue juju4/ansible-firefox-config#1 by copying src: "{{ fxjs_path }}.orig" on the remote machine to dest: "{{ fxjs_path }}" on the remote machine.